### PR TITLE
Update Localizable.strings

### DIFF
--- a/en/Localizable.strings
+++ b/en/Localizable.strings
@@ -270,7 +270,7 @@
 "bookshelf.layout.cards.large"  = "Large cards";
 
 "bookshelf.clean.category"        = "Delete empty";
-"bookshelf.clean.category.fmt"    = "Are you sure want to clean category %@ and delete %@?";
+"bookshelf.clean.category.fmt"    = "Are you sure you want to clean the '%@' category by removing %@ that are unused? (This operation does NOT delete any books.)";
 "bookshelf.insert.category.done"  = "Done, a category has been added";
 
 "bookshelf.collection"          = "Collection";


### PR DESCRIPTION
Tidied up "bookshelf.clean.category.fmt"

NOTE: I came across this after installing KyBook 3 for my partner and deleting the default books. Seeing the word 'Delete' and the trash icon made me worry I would lose books.

So, I think:
1. "bookshelf.clean.category" should hold "Tidy up" (basically anything OTHER than "Delete empty").
2. The dialogue should have "Cancel | Tidy" NOT "Cancel | Delete"
3. The icon on the category's menu should be a broom or (feather) duster icon NOT the trash can, which should be reserved for deleting books.

But again, my preference would be for KyBook 3 to clean up empty categories when books are deleted, so that the delete empty function was redundant.